### PR TITLE
Add link to the fed-tester in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,3 +2,5 @@
 <a href="https://liberapay.com/f0x/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a>  
 
 React.js frontend for the [federation-tester api](https://github.com/matrix-org/matrix-federation-tester)
+
+Try it here: https://neo.lain.haus/fed-tester/


### PR DESCRIPTION
I keep coming to this repo and not being able to find the link to the actual working fed-tester

If you want to word it differently thats fine with me but you should have a link on here somewhere to get to the hosted version